### PR TITLE
Fix createOrUpdate endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 /src/generated/
 /.env
 /db-source.json
+/db.json

--- a/README.md
+++ b/README.md
@@ -8,31 +8,42 @@ It logs the information of the incoming requests, validates their payload, and s
 _Note: the mocked implementation is based on the api-version `2015-01` of Azure Notification Hubs REST API,
 hence the behaviour of the endpoints could differ from the expected if they are invoked with another api-version._
 
+## Setup
 
-
-##Setup
 1. clone this repository
 2. install all packages needed:<br/>
-  `yarn install`
+   `yarn install`
 3. build the app:<br/>
- `yarn build`
+   `yarn build`
 4. set the required environment variables described in the related section
 5. start the server:<br/>
-  `yarn start`
+   `yarn start`
 
-###Environment variables
+### Environment variables
+
 The table lists the environment variables needed by the application, they must be customized as needed.
 For your convenience a `env.example` is provided: you can copy it to an `.env` file and then change the variables with your values,
 the app will load them on start.
 
-| Variable name                          | Description                                                                       | type    |
-| -------------------------------------- | --------------------------------------------------------------------------------- | ------- |
-| BACKEND_PORT                           | Port of Express server                                                            | number  |
-| DB_SOURCE                              | The path of the JSON file used to store the data                                  | number  |
-| EMAIL_PASSWORD                         | The password used to connect to the email server                                  | string  |
-| EMAIL_USER                             | The user to connect to the email server                                           | string  |
-| EMAIL_SMTP_HOST                        | The hostname or IP address of the SMTP server                                     | string  |
-| EMAIL_SMTP_PORT                        | The port of the SMTP server                                                       | int     |
-| EMAIL_SMTP_SECURE                      | If set to true, uses TLS in SMTP connection                                       | boolean |
-| EMAIL_SENDER                           | The email address of the sender                                                   | string  |
-| EMAIL_RECIPIENT                        | The email address of the recipient                                                | string  |
+| Variable name     | Description                                      | type    |
+| ----------------- | ------------------------------------------------ | ------- |
+| BACKEND_PORT      | Port of Express server                           | number  |
+| DB_SOURCE         | The path of the JSON file used to store the data | number  |
+| EMAIL_PASSWORD    | The password used to connect to the email server | string  |
+| EMAIL_USER        | The user to connect to the email server          | string  |
+| EMAIL_SMTP_HOST   | The hostname or IP address of the SMTP server    | string  |
+| EMAIL_SMTP_PORT   | The port of the SMTP server                      | int     |
+| EMAIL_SMTP_SECURE | If set to true, uses TLS in SMTP connection      | boolean |
+| EMAIL_SENDER      | The email address of the sender                  | string  |
+| EMAIL_RECIPIENT   | The email address of the recipient               | string  |
+
+## Postman Collection Tests
+
+A file name `test.postman_collection.json` contains a simple set of tests.
+For running this collection you can either open it into Postman or run it using [newman](https://support.postman.com/hc/en-us/articles/115003710329-What-is-Newman-)
+
+For run it using newman, just call:
+
+```
+newman run test.postman_collection.json --insecure
+```

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ the app will load them on start.
 ## Postman Collection Tests
 
 A file name `test.postman_collection.json` contains a simple set of tests.
-For running this collection you can either open it into Postman or run it using [newman](https://support.postman.com/hc/en-us/articles/115003710329-What-is-Newman-)
+To run this collection you can either open it into Postman or run it using [newman](https://support.postman.com/hc/en-us/articles/115003710329-What-is-Newman-)
 
-For run it using newman, just call:
+**NOTE: It's necessary that the application has been started using `yarn start` to run the test.**
+
+To run it using newman, just call:
 
 ```
 newman run test.postman_collection.json --insecure

--- a/src/app.ts
+++ b/src/app.ts
@@ -97,7 +97,7 @@ function registerInstallationsRoutes(
   app: Express,
   db: LowdbAsync<IDbSchema>
 ): Express {
-  app.put("/:notificationHub/installations", (req, res) => {
+  app.put("/:notificationHub/installations/:installationId", (req, res) => {
     const endpointInfo = `${req.url} ${req.method}`;
     const requestInfo = getRequestInfo(req);
     log.info(`[${endpointInfo}] Request info: %s`, requestInfo);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -36,7 +36,7 @@ paths:
           description: No message branch at the URI.
         413:
           description: Requested entity too large. The message size cannot be over 64 Kb.
-  /{notificationHub}/installations:
+  /{notificationHub}/installations/{installationId}:
     parameters:
       - $ref: "#/parameters/notificationHubParam"
       - $ref: "#/parameters/api-version"
@@ -60,16 +60,15 @@ paths:
           description: Authorization failure.
         403:
           description: Too many installations in this namespace - Installations not created.
-  /{notificationHub}/installations/{installationId}:
-    parameters:
-      - $ref: "#/parameters/notificationHubParam"
-      - description: The installation Id
-        in: path
-        name: installationId
-        required: true
-        type: string
-      - $ref: "#/parameters/api-version"
     delete:
+      parameters:
+        - $ref: "#/parameters/notificationHubParam"
+        - description: The installation Id
+          in: path
+          name: installationId
+          required: true
+          type: string
+        - $ref: "#/parameters/api-version"
       description: |-
         The original method deletes an installation.
         See [REST API method references](https://docs.microsoft.com/en-us/rest/api/notificationhubs/delete-installation).

--- a/test.postman_collection.json
+++ b/test.postman_collection.json
@@ -1,0 +1,834 @@
+{
+	"info": {
+		"_postman_id": "bdb89788-8702-4123-aa7a-912c2220d2cf",
+		"name": "Azure NotificationHub specifications",
+		"description": "Specifications file for a mock server of Azure NotificationHub based on API version 2015-01.\nSee [Notification Hubs REST API method references](https://docs.microsoft.com/en-us/rest/api/notificationhubs/rest-api-methods)",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "{notification Hub}",
+			"item": [
+				{
+					"name": "installations/{installation Id}",
+					"item": [
+						{
+							"name": "/:notificationHub/installations/:installationId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response is 200\", () => {",
+											"    pm.response.to.have.status(200);",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"installationId\": \"cff299cd50dff7cfa143a6a7fa4f89c4f4095dc4614b1d249b9bd9c7070a91dc\",\n    \"platform\": \"gmc\",\n    \"pushChannel\": \"epbR8dxGSuGteiWkka5tiS:APA91bHhXQfnOAHudsXmYG9xzqNon8BylHDEzwFAF7oradEof15sRp-U2A-nlAnEJaq_oi44TDV6tmCVzTYzYsNN3EIxREWEnFJtT4uI-AiGK0KPe8T1LKPhOBrhHwwr3SWl-RF3rPj\",\n    \"tags\": [\n        \"cff299cd50dff7cfa143a6a7fa4f89c4f4095dc4614b1d249b9bd9c7070a91dc\"\n    ],\n    \"templates\": {\n        \"template\": {\n            \"body\": \"ciao\"\n            }\n        },\n    \"secondaryTiles\": {}\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/installations/{{installationId}}?api-version=1.0",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"installations",
+										"{{installationId}}"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "1.0",
+											"description": "(Required) The API version used by the client"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub",
+											"value": "notificationHub",
+											"description": "(Required) The Notification Hub name"
+										}
+									]
+								},
+								"description": "The original method creates or overwrites an installation.\nSee [REST API method references](https://docs.microsoft.com/en-us/rest/api/notificationhubs/create-overwrite-installation)."
+							},
+							"response": [
+								{
+									"name": "Authorization failure.",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"installationId\": \"et\",\n    \"platform\": \"esse ex adipisicing\",\n    \"pushChannel\": \"ipsum adipisicing\",\n    \"lastActiveOn\": \"velit sunt\",\n    \"expirationTime\": \"ut\",\n    \"lastUpdate\": \"laboris sunt\",\n    \"expiredPushChannel\": true,\n    \"tags\": [\n        \"nostrud\",\n        \"enim sunt Excepteur\"\n    ],\n    \"templates\": {},\n    \"secondaryTiles\": {}\n}"
+										},
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								},
+								{
+									"name": "Installation was queued successfully and will be processed in the background.",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"installationId\": \"et\",\n    \"platform\": \"esse ex adipisicing\",\n    \"pushChannel\": \"ipsum adipisicing\",\n    \"lastActiveOn\": \"velit sunt\",\n    \"expirationTime\": \"ut\",\n    \"lastUpdate\": \"laboris sunt\",\n    \"expiredPushChannel\": true,\n    \"tags\": [\n        \"nostrud\",\n        \"enim sunt Excepteur\"\n    ],\n    \"templates\": {},\n    \"secondaryTiles\": {}\n}"
+										},
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								},
+								{
+									"name": "Malformed request.",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"installationId\": \"et\",\n    \"platform\": \"esse ex adipisicing\",\n    \"pushChannel\": \"ipsum adipisicing\",\n    \"lastActiveOn\": \"velit sunt\",\n    \"expirationTime\": \"ut\",\n    \"lastUpdate\": \"laboris sunt\",\n    \"expiredPushChannel\": true,\n    \"tags\": [\n        \"nostrud\",\n        \"enim sunt Excepteur\"\n    ],\n    \"templates\": {},\n    \"secondaryTiles\": {}\n}"
+										},
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "Bad Request",
+									"code": 400,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								},
+								{
+									"name": "Too many installations in this namespace - Installations not created.",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"installationId\": \"et\",\n    \"platform\": \"esse ex adipisicing\",\n    \"pushChannel\": \"ipsum adipisicing\",\n    \"lastActiveOn\": \"velit sunt\",\n    \"expirationTime\": \"ut\",\n    \"lastUpdate\": \"laboris sunt\",\n    \"expiredPushChannel\": true,\n    \"tags\": [\n        \"nostrud\",\n        \"enim sunt Excepteur\"\n    ],\n    \"templates\": {},\n    \"secondaryTiles\": {}\n}"
+										},
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "Forbidden",
+									"code": 403,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "/:notificationHub/installations/:installationId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response is 204\", () => {",
+											"    pm.response.to.have.status(204);",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/installations/{{installationId}}?api-version=1.0",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"installations",
+										"{{installationId}}"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "1.0",
+											"description": "(Required) The API version used by the client"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub",
+											"value": "notificationHub",
+											"description": "(Required) The Notification Hub name"
+										}
+									]
+								},
+								"description": "The original method deletes an installation.\nSee [REST API method references](https://docs.microsoft.com/en-us/rest/api/notificationhubs/delete-installation)."
+							},
+							"response": [
+								{
+									"name": "Authorization failure",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								},
+								{
+									"name": "Malformed request",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "Bad Request",
+									"code": 400,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								},
+								{
+									"name": "Quota exceeded",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "Forbidden",
+									"code": 403,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								},
+								{
+									"name": "The installation was deleted successfully or was not found",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/:notificationHub/installations/:installationId?api-version=exercitation ut",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												":notificationHub",
+												"installations",
+												":installationId"
+											],
+											"query": [
+												{
+													"key": "api-version",
+													"value": "exercitation ut"
+												}
+											],
+											"variable": [
+												{
+													"key": "notificationHub"
+												},
+												{
+													"key": "installationId"
+												}
+											]
+										}
+									},
+									"status": "No Content",
+									"code": 204,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "/:notificationHub/messages",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is 200\", () => {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "ServiceBusNotification-Tags",
+								"value": "$InstallationId:{{installationId}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/:notificationHub/messages?api-version=1.0",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								":notificationHub",
+								"messages"
+							],
+							"query": [
+								{
+									"key": "api-version",
+									"value": "1.0",
+									"description": "(Required) The API version used by the client"
+								}
+							],
+							"variable": [
+								{
+									"key": "notificationHub",
+									"value": "notificationHub",
+									"description": "(Required) The Notification Hub name"
+								}
+							]
+						},
+						"description": "The original method sends a notification to a template registration on a notification hub.\nSee [REST API method references](https://docs.microsoft.com/en-us/rest/api/notificationhubs/send-template-notification)."
+					},
+					"response": [
+						{
+							"name": "No message branch at the URI.",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/messages?api-version=exercitation ut",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"messages"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "exercitation ut"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub"
+										}
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						},
+						{
+							"name": "Malformed request.",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/messages?api-version=exercitation ut",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"messages"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "exercitation ut"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub"
+										}
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						},
+						{
+							"name": "Quota exceeded or message too large; message was rejected.",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/messages?api-version=exercitation ut",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"messages"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "exercitation ut"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub"
+										}
+									]
+								}
+							},
+							"status": "Forbidden",
+							"code": 403,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						},
+						{
+							"name": "Requested entity too large. The message size cannot be over 64 Kb.",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/messages?api-version=exercitation ut",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"messages"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "exercitation ut"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub"
+										}
+									]
+								}
+							},
+							"status": "Request Entity Too Large",
+							"code": 413,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						},
+						{
+							"name": "Authorization failure.",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/messages?api-version=exercitation ut",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"messages"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "exercitation ut"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub"
+										}
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						},
+						{
+							"name": "Message successfully sent.",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/:notificationHub/messages?api-version=exercitation ut",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										":notificationHub",
+										"messages"
+									],
+									"query": [
+										{
+											"key": "api-version",
+											"value": "exercitation ut"
+										}
+									],
+									"variable": [
+										{
+											"key": "notificationHub"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "https://localhost:3000"
+		},
+		{
+			"key": "installationId",
+			"value": "cff299cd50dff7cfa143a6a7fa4f89c4f4095dc4614b1d249b9bd9c7070a91dc"
+		}
+	]
+}


### PR DESCRIPTION
#### List of Changes
- Added _installationId_ as path parameter within the _createorUpdate_ endpoint
- Updated the swagger.yaml file accordingly
- added _test.postman_collection.json_ with some basic tests


#### Motivation and Context
Fix the _CreateOrUpdate_ endpoint accordingly to the [documentation](https://docs.microsoft.com/it-it/rest/api/notificationhubs/create-overwrite-installation)

#### How Has This Been Tested?
It has been tested by performing `newman run test.postman_collection.json --insecure` after `yarn start`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.